### PR TITLE
Add Flights to a Historical Database

### DIFF
--- a/src/History/FlightTracker.FlightHistory.API/Cache/FlightCache.cs
+++ b/src/History/FlightTracker.FlightHistory.API/Cache/FlightCache.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+
+namespace FlightTracker.FlightHistory.API.Cache
+{
+    public class FlightCache
+    {
+        public MemoryCache Cache { get; } = new MemoryCache(new MemoryCacheOptions());
+    }
+}

--- a/src/History/FlightTracker.FlightHistory.API/FlightTracker.FlightHistory.API.csproj
+++ b/src/History/FlightTracker.FlightHistory.API/FlightTracker.FlightHistory.API.csproj
@@ -10,14 +10,20 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="MassTransit" Version="8.0.0" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Controllers\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Common\FlightTracker.Common\FlightTracker.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/History/FlightTracker.FlightHistory.API/Models/Flight.cs
+++ b/src/History/FlightTracker.FlightHistory.API/Models/Flight.cs
@@ -1,0 +1,11 @@
+﻿namespace FlightTracker.FlightHistory.API.Models
+{
+    public class Flight
+    {
+        public int Id { get; set; }
+
+        public string Hex { get; set; }
+
+        public string FlightNumber { get; set; }
+    }
+}

--- a/src/History/FlightTracker.FlightHistory.API/Program.cs
+++ b/src/History/FlightTracker.FlightHistory.API/Program.cs
@@ -28,6 +28,7 @@
 
 
 using System.Reflection;
+using FlightTracker.FlightHistory.API.Cache;
 using FlightTracker.FlightHistory.API.Repository;
 using MassTransit;
 
@@ -50,6 +51,8 @@ namespace TrackFetcher
 
                     services.AddEndpointsApiExplorer();
                     services.AddSwaggerGen();
+
+                    services.AddMemoryCache();
 
                     services.AddMassTransit(x =>
                     {

--- a/src/History/FlightTracker.FlightHistory.API/Program.cs
+++ b/src/History/FlightTracker.FlightHistory.API/Program.cs
@@ -1,23 +1,71 @@
-var builder = WebApplication.CreateBuilder(args);
+//using FlightTracker.FlightHistory.API.Repository;
 
-// Add services to the container.
+//var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+//// Add services to the container.
 
-var app = builder.Build();
+//builder.Services.AddControllers();
+//// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+//builder.Services.AddEndpointsApiExplorer();
+//builder.Services.AddSwaggerGen();
 
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+//builder.Services.AddScoped<IFlightRepository, FlightRepository>();
+
+//var app = builder.Build();
+
+//// Configure the HTTP request pipeline.
+//if (app.Environment.IsDevelopment())
+//{
+//    app.UseSwagger();
+//    app.UseSwaggerUI();
+//}
+
+//app.UseAuthorization();
+
+//app.MapControllers();
+
+//app.Run();
+
+
+using System.Reflection;
+using FlightTracker.FlightHistory.API.Repository;
+using MassTransit;
+
+namespace TrackFetcher
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            await CreateHostBuilder(args).Build().RunAsync();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddScoped<IFlightRepository, FlightRepository>();
+
+                    services.AddControllers();
+
+                    services.AddEndpointsApiExplorer();
+                    services.AddSwaggerGen();
+
+                    services.AddMassTransit(x =>
+                    {
+                        x.SetKebabCaseEndpointNameFormatter();
+
+                        var entryAssembly = Assembly.GetEntryAssembly();
+
+                        x.AddConsumers(entryAssembly);
+
+                        x.UsingRabbitMq((ctx, cfg) =>
+                        {
+                            cfg.Host("amqp://guest:guest@track-rabbitmq:5672");
+
+                            cfg.ConfigureEndpoints(ctx);
+                        });
+                    });
+                });
+    }
 }
-
-app.UseAuthorization();
-
-app.MapControllers();
-
-app.Run();

--- a/src/History/FlightTracker.FlightHistory.API/Repository/FlightRepository.cs
+++ b/src/History/FlightTracker.FlightHistory.API/Repository/FlightRepository.cs
@@ -1,0 +1,68 @@
+﻿using FlightTracker.Common;
+using Npgsql;
+using Dapper;
+using FlightTracker.FlightHistory.API.Models;
+
+namespace FlightTracker.FlightHistory.API.Repository
+{
+    public class FlightRepository : IFlightRepository
+    {
+        private readonly string _connectionString;
+
+        public FlightRepository()
+        {
+            _connectionString = "";
+        }
+
+        public async Task<int> AddFlight(Flight flight)
+        {
+            using var connection = new NpgsqlConnection(_connectionString);
+
+            string sql = @"INSERT INTO Flight (Hex, FlightNumber) VALUES (@Hex, @FlightNumber) RETURNING Id";
+
+            var p = new
+            {
+                Hex = flight.Hex,
+                FlightNumber = flight.FlightNumber,
+            };
+
+            int result = await connection.ExecuteAsync(sql, param: p);
+
+            return result;
+        }
+
+        public async Task<bool> AddFlightStatus(ADSBPing adsPing, int flightId)
+        {
+            using var connection = new NpgsqlConnection(_connectionString);
+
+            string sql = @"INSERT INTO FlightStatus 
+                                (FlightId, BarometricAltitude, GeometricAltitude, GroundSpeed, 
+                                    Track, BarometricRateOfChange, Squawk, Latitude, Longitude) 
+                            VALUES (@FlightId, @BarometricAltitude, @GeometricAltitude, @GroundSpeed, @Track,
+                                    @BarometricRateOfChange, @Squawk, @Latitude, @Longitude) RETURNING Id";
+
+            var p = new
+            {
+                FlightId = flightId,
+                BarometricAltitude = adsPing.BarometricAltitude,
+                GeometricAltitude = adsPing.GeometricAltitude,
+                GroundSpeed = adsPing.GroundSpeed,
+                Track = adsPing.Track,
+                BarometricRateOfChange = adsPing.BarometricRateOfChange,
+                Squawk = adsPing.Squawk,
+                Latitude = adsPing.Latitude,
+                Longitude = adsPing.Longitude,
+            };
+
+            int result = await connection.ExecuteAsync(sql, param: p);
+
+            return result > 0;
+        }
+
+        public async Task<IEnumerable<ADSBPing>> GetTrackByFlightId(int flightId)
+        {
+            throw new NotImplementedException();
+        }
+
+    }
+}

--- a/src/History/FlightTracker.FlightHistory.API/Repository/FlightRepository.cs
+++ b/src/History/FlightTracker.FlightHistory.API/Repository/FlightRepository.cs
@@ -11,7 +11,7 @@ namespace FlightTracker.FlightHistory.API.Repository
 
         public FlightRepository()
         {
-            _connectionString = "";
+            _connectionString = "Server=FlightHistoryDb;Port=5432;Database=FlightHistoryDb;User Id=admin;Password=admin1234;";
         }
 
         public async Task<int> AddFlight(Flight flight)
@@ -26,7 +26,7 @@ namespace FlightTracker.FlightHistory.API.Repository
                 FlightNumber = flight.FlightNumber,
             };
 
-            int result = await connection.ExecuteAsync(sql, param: p);
+            int result = await connection.ExecuteScalarAsync<int>(sql, param: p);
 
             return result;
         }

--- a/src/History/FlightTracker.FlightHistory.API/Repository/IFlightRepository.cs
+++ b/src/History/FlightTracker.FlightHistory.API/Repository/IFlightRepository.cs
@@ -1,0 +1,14 @@
+﻿using FlightTracker.Common;
+using FlightTracker.FlightHistory.API.Models;
+
+namespace FlightTracker.FlightHistory.API.Repository
+{
+    public interface IFlightRepository
+    {
+        public Task<int> AddFlight(Flight flight);
+
+        public Task<bool> AddFlightStatus(ADSBPing adsPing, int flightId);
+
+        public Task<IEnumerable<ADSBPing>> GetTrackByFlightId(int flightId);
+    }
+}

--- a/src/History/FlightTracker.FlightHistory.API/Sql/PostgresNotes.txt
+++ b/src/History/FlightTracker.FlightHistory.API/Sql/PostgresNotes.txt
@@ -18,7 +18,7 @@ Using REAL for the number columns gets 6 digits of precision, good enough for te
 
 CREATE TABLE FlightStatus (
 	Id						BIGSERIAL PRIMARY KEY NOT NULL,
-	FlightId				??,
+	FlightId				INT NOT NULL,
 	BarometricAltitude		INT,
 	GeometricAltitude		INT,
 	GroundSpeed				REAL,

--- a/src/History/FlightTracker.FlightHistory.API/Sql/PostgresNotes.txt
+++ b/src/History/FlightTracker.FlightHistory.API/Sql/PostgresNotes.txt
@@ -1,0 +1,31 @@
+﻿Just a scratchpad for postgres stuff
+
+Lots of enhancements could be made - doing this for real, I'd probably put this in TimescaleDb and maybe use PostGIS too
+___________
+
+Main table for flights
+
+CREATE TABLE Flight (
+	Id				SERIAL PRIMARY KEY NOT NULL,
+	Hex				VARCHAR(10) NOT NULL,
+	FlightNumber	VARCHAR(10)
+)
+
+____________
+
+Leaving several columns off of this as this is just a proof of concept
+Using REAL for the number columns gets 6 digits of precision, good enough for testing this out
+
+CREATE TABLE FlightStatus (
+	Id						BIGSERIAL PRIMARY KEY NOT NULL,
+	FlightId				??,
+	BarometricAltitude		INT,
+	GeometricAltitude		INT,
+	GroundSpeed				REAL,
+	Track					REAL,
+	BarometricRateOfChange	INT,
+	Squawk					VARCHAR(10),
+	Latitude				REAL,
+	Longitude				REAL,
+	CONSTRAINT fk_flightid FOREIGN KEY(FlightId) REFERENCES Flight(Id)
+)

--- a/src/History/FlightTracker.FlightHistory.API/Workers/HistoryIngestWorker.cs
+++ b/src/History/FlightTracker.FlightHistory.API/Workers/HistoryIngestWorker.cs
@@ -1,0 +1,24 @@
+﻿using FlightTracker.Common;
+using MassTransit;
+
+namespace FlightTracker.FlightHistory.API.Workers
+{
+    public class HistoryIngestWorker : IConsumer<PiAwareLog>
+    {
+        readonly ILogger<HistoryIngestWorker> _logger;
+
+        public HistoryIngestWorker(ILogger<HistoryIngestWorker> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task Consume(ConsumeContext<PiAwareLog> context)
+        {
+            _logger.LogInformation("Recieved message");
+
+            var test = context;
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/History/FlightTracker.FlightHistory.API/Workers/HistoryIngestWorker.cs
+++ b/src/History/FlightTracker.FlightHistory.API/Workers/HistoryIngestWorker.cs
@@ -1,24 +1,65 @@
 ﻿using FlightTracker.Common;
+using FlightTracker.FlightHistory.API.Models;
+using FlightTracker.FlightHistory.API.Repository;
 using MassTransit;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace FlightTracker.FlightHistory.API.Workers
 {
     public class HistoryIngestWorker : IConsumer<PiAwareLog>
     {
         readonly ILogger<HistoryIngestWorker> _logger;
+        private readonly IMemoryCache _cache;
+        private readonly IFlightRepository _repository;
 
-        public HistoryIngestWorker(ILogger<HistoryIngestWorker> logger)
+        public HistoryIngestWorker(ILogger<HistoryIngestWorker> logger, IMemoryCache cache, IFlightRepository repository)
         {
             _logger = logger;
+            _cache = cache;
+            _repository = repository;
         }
 
-        public Task Consume(ConsumeContext<PiAwareLog> context)
+        // TODO: add expiration on cache
+        public async Task Consume(ConsumeContext<PiAwareLog> context)
         {
-            _logger.LogInformation("Recieved message");
+            var message = context.Message;
 
-            var test = context;
+            foreach (var aicraft in message.Aircraft)
+            {
+                int existingId = 0;
 
-            return Task.CompletedTask;
+                _cache.TryGetValue(aicraft.Hex, out existingId);
+
+                if (existingId != 0)
+                {
+                    // plane has already been added to the DB, append this to the existing flight
+                    await _repository.AddFlightStatus(aicraft, existingId);
+                }
+                else
+                {
+                    // this is a new instance of this hex (at this point in time)
+                    _logger.LogInformation("New flight seen: {hex}", aicraft.Hex);
+
+                    // guaranteed to get hex every time, but everything else may be null
+                    // TODO: what if flight number is null on first ping and we get it later on? need a way to patch it
+                    var flightToAdd = new Flight
+                    {
+                        Hex = aicraft.Hex,
+                        FlightNumber = aicraft.Flight
+                    };
+
+                    // add the flight to the db and get the ID back
+                    int newId = await _repository.AddFlight(flightToAdd);
+
+                    // add this ping to the new flight
+                    await _repository.AddFlightStatus(aicraft, newId);
+
+                    // add that ID to cache
+                    _cache.Set(aicraft.Hex, newId);
+                }
+            }
+
+            return;
         }
     }
 }

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       dockerfile: History/FlightTracker.FlightHistory.API/Dockerfile
     ports:
       - "8000:80"
+    depends_on:
+      - flighthistorydb
 
   flighttracker.datafetch:
     image: ${DOCKER_REGISTRY-}flighttrackerdatafetch
@@ -36,6 +38,7 @@ services:
 
   flighthistorydb:
     image: postgres
+    container_name: flighthistorydb
     environment:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=admin1234


### PR DESCRIPTION
Bringing this in as the general idea is now functional. This PR introduces a worker which listens to RabbitMQ messages. The data structure is simple - one table for Flights, and a linked table with details of each ADS-B ping.

To increase performance and keep from having to query the DB for a Flight ID each time I want to add a new ping, I added a quick MemoryCache singleton which just keeps a Hex and the Flight ID from the database. In a production setting and with higher volume, this would of course be better off in a distributed cache like Redis, but for a proof of concept this works well.

There are several areas to address next:
- Add an expiration to items in cache, currently it just keeps growing endlessly. I think an expiry of around 5 minutes is a good start, probably using a SetSlidingExpiration.
- Add a way to patch flight number on the Flight table, if it was not received in the first ping. Sometimes it's null, but the Hex always comes through.
- Check each ping to see if it's new, before adding it to the DB. Could probably compare last_seen or messages field to see if those are the same.